### PR TITLE
Add authorized user management to diploma contract

### DIFF
--- a/smart contract/contracts/DiplomaContract.sol
+++ b/smart contract/contracts/DiplomaContract.sol
@@ -1,18 +1,63 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-contract DiplomaContract {
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title DiplomaContract
+ * @dev Stores IPFS links for diplomas and manages authorized users.
+ */
+contract DiplomaContract is Ownable {
     bytes32 public merkleRoot;
+
+    // Mapping of diploma leaf to its IPFS link
     mapping(bytes32 => string) public diplomaIpfsLinks;
 
-    constructor(bytes32 _root) {
+    // Tracks addresses allowed to register diplomas
+    mapping(address => bool) public authorizedUsers;
+
+    constructor(bytes32 _root) Ownable(msg.sender) {
         merkleRoot = _root;
     }
 
-    function registerDiploma(bytes32 leaf, string memory ipfsLink) public {
+    /**
+     * @dev Adds an address as an authorized user. Only callable by the owner.
+     * @param user Address to authorize.
+     */
+    function addAuthorizedUser(address user) external onlyOwner {
+        authorizedUsers[user] = true;
+    }
+
+    /**
+     * @dev Removes an address from the list of authorized users. Only callable by the owner.
+     * @param user Address to deauthorize.
+     */
+    function removeAuthorizedUser(address user) external onlyOwner {
+        authorizedUsers[user] = false;
+    }
+
+    /**
+     * @dev Restricts function access to authorized users.
+     */
+    modifier onlyAuthorized() {
+        require(authorizedUsers[msg.sender], "User not authorized");
+        _;
+    }
+
+    /**
+     * @dev Registers a diploma IPFS link for a given leaf. Only authorized users can call.
+     * @param leaf Merkle tree leaf of the diploma.
+     * @param ipfsLink IPFS link associated with the diploma.
+     */
+    function registerDiploma(bytes32 leaf, string memory ipfsLink) public onlyAuthorized {
         diplomaIpfsLinks[leaf] = ipfsLink;
     }
 
+    /**
+     * @dev Retrieves the IPFS link for a given diploma leaf.
+     * @param leaf Merkle tree leaf of the diploma.
+     * @return The IPFS link stored for the diploma.
+     */
     function getDiplomaIpfs(bytes32 leaf) public view returns (string memory) {
         return diplomaIpfsLinks[leaf];
     }

--- a/smart contract/package.json
+++ b/smart contract/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "hardhat test"
   },
   "keywords": [],
   "author": "",

--- a/smart contract/test/DiplomaContract.js
+++ b/smart contract/test/DiplomaContract.js
@@ -1,0 +1,38 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("DiplomaContract user management", function () {
+  it("allows owner to authorize users and restricts access", async function () {
+    const [owner, authorized, stranger] = await ethers.getSigners();
+    const DiplomaContract = await ethers.getContractFactory("DiplomaContract");
+    const contract = await DiplomaContract.deploy(ethers.constants.HashZero);
+    await contract.deployed();
+
+    // Unauthorized user should not be able to register a diploma
+    try {
+      await contract
+        .connect(stranger)
+        .registerDiploma(ethers.constants.HashZero, "ipfs://test");
+      expect.fail("Expected revert not received");
+    } catch (error) {
+      expect(error.message).to.include("User not authorized");
+    }
+
+    // Owner authorizes a user
+    await contract.addAuthorizedUser(authorized.address);
+    const leaf = ethers.utils.formatBytes32String("leaf");
+    await contract.connect(authorized).registerDiploma(leaf, "ipfs://link");
+    expect(await contract.getDiplomaIpfs(leaf)).to.equal("ipfs://link");
+
+    // Authorization can be revoked
+    await contract.removeAuthorizedUser(authorized.address);
+    try {
+      await contract
+        .connect(authorized)
+        .registerDiploma(ethers.constants.HashZero, "ipfs://test2");
+      expect.fail("Expected revert not received");
+    } catch (error) {
+      expect(error.message).to.include("User not authorized");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- restrict diploma registration to owner-authorized addresses
- cover authorization workflow with a Hardhat test
- set npm test script to run Hardhat tests

## Testing
- `npm test` *(fails: Couldn't download compiler version list; network 403)*

------
https://chatgpt.com/codex/tasks/task_e_68907b9c2c2c8326b30254c665e91897