### PR TITLE
feat: add blockchain simulation script

### DIFF
--- a/smart contract/README.md
+++ b/smart contract/README.md
@@ -1,0 +1,52 @@
+# Blockchain Simulation with Hardhat
+
+This project demonstrates how to simulate and interact with a blockchain using Hardhat. It covers running a local node, creating accounts, sending transactions, deploying a contract, and ideas for autonomous behaviors.
+
+## 1. Réseau local ou testnet
+- **Local Hardhat Network**: start a local blockchain with:
+  ```bash
+  npx hardhat node
+  ```
+- **Testnet (ex. Sepolia)**: configure the `networks` section in `hardhat.config.js` with a private key and an RPC URL.
+
+## 2. Création de comptes
+- On the local network, Hardhat automatically exposes several accounts (signers).
+- On public networks or testnets, create accounts from a private key or mnemonic and fund them via a faucet.
+
+## 3. Transactions
+- Every interaction is a transaction: transferring ETH or invoking contract functions.
+- Transactions must be signed by the sender's private key and are included in blocks by miners/validators.
+
+## 4. Déploiement et interaction avec un contrat
+1. Write the contract in Solidity.
+2. Deploy and interact via scripts using Ethers.js and the local Hardhat node.
+   The provided script compile le contrat à la volée avec `solc` puis le déploie :
+   ```bash
+   node scripts/blockchainSimulation.js
+   ```
+
+## 5. Contrats autonomes
+- Contracts execute only when a transaction triggers them.
+- To automate behavior, use external scripts or services (cron, keeper, oracles) that send transactions periodically.
+- In tests, time and events can be simulated with Hardhat helpers such as `evm_increaseTime` and `evm_mine`.
+
+## Commands to test
+1. Install dependencies (if not already):
+   ```bash
+   npm install
+   ```
+2. Start a local node:
+   ```bash
+   npx hardhat node
+   ```
+3. In another terminal, run the demo script against the node:
+   ```bash
+   node scripts/blockchainSimulation.js
+   ```
+
+Or run all the above steps automatically with:
+  ```bash
+  bash scripts/runDemo.sh
+  ```
+
+The script will show account balances, send an ETH transfer, compile and deploy `DiplomaContract`, and store/read a simulated diploma IPFS link.

--- a/smart contract/scripts/blockchainSimulation.js
+++ b/smart contract/scripts/blockchainSimulation.js
@@ -1,0 +1,63 @@
+const fs = require("fs");
+const path = require("path");
+const solc = require("solc");
+const { ethers } = require("ethers");
+
+async function main() {
+  // Connexion au nœud local Hardhat
+  const provider = new ethers.providers.JsonRpcProvider("http://127.0.0.1:8545");
+  const accounts = await provider.listAccounts();
+  const deployer = provider.getSigner(accounts[0]);
+  const user = provider.getSigner(accounts[1]);
+
+  console.log("Deployer:", accounts[0]);
+  console.log("User:", accounts[1]);
+
+  console.log("Deployer balance:", (await deployer.getBalance()).toString());
+  console.log("User balance:", (await user.getBalance()).toString());
+
+  // Transaction d'ETH entre comptes
+  console.log("\nSending 1 ETH from deployer to user...");
+  const tx = await deployer.sendTransaction({
+    to: accounts[1],
+    value: ethers.utils.parseEther("1"),
+  });
+  await tx.wait();
+
+  console.log("Deployer balance after:", (await deployer.getBalance()).toString());
+  console.log("User balance after:", (await user.getBalance()).toString());
+
+  // Compilation du contrat avec solc
+  const source = fs.readFileSync(path.join(__dirname, "../contracts/DiplomaContract.sol"), "utf8");
+  const input = {
+    language: "Solidity",
+    sources: { "DiplomaContract.sol": { content: source } },
+    settings: { outputSelection: { "*": { "*": ["abi", "evm.bytecode"] } } },
+  };
+  const output = JSON.parse(solc.compile(JSON.stringify(input)));
+  const contract = output.contracts["DiplomaContract.sol"]["DiplomaContract"];
+  const abi = contract.abi;
+  const bytecode = contract.evm.bytecode.object;
+
+  // Déploiement du smart contract
+  const factory = new ethers.ContractFactory(abi, bytecode, deployer);
+  const merkleRoot = ethers.constants.HashZero;
+  const diploma = await factory.deploy(merkleRoot);
+  await diploma.deployed();
+  console.log("DiplomaContract deployed at:", diploma.address);
+
+  // Interaction avec le contrat
+  const leaf = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("student1"));
+  const ipfs = "ipfs://exampleHash";
+  const regTx = await diploma.registerDiploma(leaf, ipfs);
+  await regTx.wait();
+  console.log("Diploma registered");
+
+  const stored = await diploma.getDiplomaIpfs(leaf);
+  console.log("Stored IPFS:", stored);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/smart contract/scripts/runDemo.sh
+++ b/smart contract/scripts/runDemo.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install dependencies if needed
+npm install
+
+# Start a local Hardhat node in the background
+npx hardhat node &
+NODE_PID=$!
+# Allow the node time to start
+sleep 3
+
+# Run the blockchain simulation script against the local node
+node scripts/blockchainSimulation.js
+
+# Stop the Hardhat node
+kill $NODE_PID


### PR DESCRIPTION
## Summary
- add Hardhat script demonstrating accounts, transactions, deployment, and interaction
- document how to simulate a blockchain with Hardhat, including commands to run the demo
- provide helper script to automatically run installation, compilation, local node, and demo
- compile contract with solc directly to avoid Hardhat compiler downloads

## Testing
- `npm test` *(fails: Error: no test specified)*
- `bash scripts/runDemo.sh`


------
https://chatgpt.com/codex/tasks/task_e_6891cbd76208832688cef4174e2e75cd